### PR TITLE
fixed BIT ajax so that calls are paired with band names

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -96,10 +96,11 @@ $(document).ready(function () {
                     var BITURL = "https://rest.bandsintown.com/artists/" + favoriteArtists[i] + "/events?app_id=" + BIT_Id;
                     $.ajax({
                         url: BITURL,
-                        method: "GET"
+                        method: "GET",
+                        ajaxI: favoriteArtists[i]
                     }).then(function (response) {
                         console.log(response);
-                        var name = favoriteArtists[i];
+                        var name = this.ajaxI;
                         // Sets each response as element of BITObjectArray (an array of JSON-style objects) so that we can pull this data to populate our page
                         BITObjectArray.push({
                             artistName: name,


### PR DESCRIPTION
Previously, BIT responses occurred out of order due to AJAX asynchronicity. Since BIT responses do not contain band names, this made the data hard to interpret. Added two lines to BIT Ajax call so that responses pushed into array are paired with band names passed in from Spotify data.